### PR TITLE
feat: add `on_clear` and user event `TransparentClear`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ require("transparent").setup({ -- Optional, you don't have to run setup.
   },
   extra_groups = {}, -- table: additional groups that should be cleared
   exclude_groups = {}, -- table: groups you don't want to clear
+  post_hook = function() end, -- function: code to be executed after highlight groups are cleared
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,17 +21,23 @@ The execution of each function in the plugin is very fast and the time consumpti
 All available options:
 
 ```lua
-require("transparent").setup({ -- Optional, you don't have to run setup.
-  groups = { -- table: default groups
+ -- Optional, you don't have to run setup.
+require("transparent").setup({
+  -- table: default groups
+  groups = {
     'Normal', 'NormalNC', 'Comment', 'Constant', 'Special', 'Identifier',
     'Statement', 'PreProc', 'Type', 'Underlined', 'Todo', 'String', 'Function',
     'Conditional', 'Repeat', 'Operator', 'Structure', 'LineNr', 'NonText',
     'SignColumn', 'CursorLine', 'CursorLineNr', 'StatusLine', 'StatusLineNC',
     'EndOfBuffer',
   },
-  extra_groups = {}, -- table: additional groups that should be cleared
-  exclude_groups = {}, -- table: groups you don't want to clear
-  post_hook = function() end, -- function: code to be executed after highlight groups are cleared
+  -- table: additional groups that should be cleared
+  extra_groups = {},
+  -- table: groups you don't want to clear
+  exclude_groups = {},
+  -- function: code to be executed after highlight groups are cleared
+  -- Also the user event "TransparentClear" will be triggered
+  on_clear = function() end,
 })
 ```
 
@@ -99,6 +105,14 @@ eg: `require("tokyonight").setup{ transparent = vim.g.transparent_enabled }`
 
 **NOTE**: The plugin will cache and automatically apply transparency settings, so you only need to call the following command.
 
+## Commands
+
+```
+:TransparentEnable
+:TransparentDisable
+:TransparentToggle
+```
+
 ## FAQ
 
 ### How to enable transparent for plugin panels?
@@ -119,14 +133,6 @@ You can try adding this highlight group to the options:
 It is not recommended to set the floating window to be transparent, it will become very weird, and everything will be mixed together.
 
 For more information: https://github.com/xiyaowong/transparent.nvim/issues?q=label%3A%22float+window%22+sort%3Aupdated-desc
-
-## Commands
-
-```
-:TransparentEnable
-:TransparentDisable
-:TransparentToggle
-```
 
 ## Migration Guide 2023/3/20
 

--- a/lua/transparent/config.lua
+++ b/lua/transparent/config.lua
@@ -11,42 +11,17 @@ local config = {
   },
   extra_groups = {},
   exclude_groups = {},
+  on_clear = function () end
 }
 -- stylua: ignore end
 
 function M.set(opts)
-    opts = opts or {}
-
-    local keys = vim.tbl_keys(opts)
-    local msgs = {}
-    if vim.tbl_contains(keys, "exclude") then
-        table.insert(msgs, '- "exclude" has been changed to "exclude_groups".')
-    end
-    if vim.tbl_contains(keys, "ignore_linked_group") then
-        table.insert(msgs, '- "ignore_linked_group" has been removed.')
-    end
-    if vim.tbl_contains(keys, "enable") then
-        table.insert(msgs, '- "enable" has been removed.')
-    end
-    if type(opts.extra_groups) == "string" then
-        table.insert(msgs, '- "extra_groups" must be a table.')
-    end
-    if not vim.tbl_isempty(msgs) then
-        table.insert(
-            msgs,
-            1,
-            "[transparent.nvim] Please check the README for detailed information."
-        )
-        local msg = table.concat(msgs, "\n")
-        vim.defer_fn(function()
-            vim.notify(msg, vim.log.levels.WARN)
-        end, 3000)
-    end
-
-    opts.enable = nil
-    opts.ignore_linked_group = nil
-    opts.exclude_groups = opts.exclude_groups or opts.exclude
-
+    vim.validate({
+        groups = { opts.groups, "t", true },
+        extra_groups = { opts.groups, "t", true },
+        exclude_groups = { opts.groups, "t", true },
+        on_clear = { opts.groups, "f", true },
+    })
     config = vim.tbl_extend("force", config, opts or {})
 end
 

--- a/lua/transparent/init.lua
+++ b/lua/transparent/init.lua
@@ -46,24 +46,31 @@ local function clear()
     -- print((vim.loop.hrtime() - start) / 1e6, "ms")
 end
 
-function M.clear()
-    if vim.g.transparent_enabled ~= true then
-        return
+local function post_hook()
+    if type(config.post_hook) == "function" then
+        pcall(config.post_hook)
     end
-    --- ? some plugins calculate colors from basic highlights
-    --- : clear immediately
-    -- local start = vim.loop.hrtime()
-    clear()
-    -- print((vim.loop.hrtime() - start) / 1e6, 'ms')
-    --- ? some plugins use autocommands to redefine highlights
-    --- : clear again after a while
-    vim.defer_fn(clear, 500)
-    --- again
-    vim.defer_fn(clear, 1e3)
-    --- yes, clear 4 times!!!
-    vim.defer_fn(clear, 3e3)
-    --- Don't worry about performance, it's very cheap!
-    vim.defer_fn(clear, 5e3)
+    vim.api.nvim_exec_autocmds("User", { pattern = "TransparentClear", modeline = false }) -- execute autocmd
+end
+
+function M.clear()
+    if vim.g.transparent_enabled then
+        --- ? some plugins calculate colors from basic highlights
+        --- : clear immediately
+        -- local start = vim.loop.hrtime()
+        clear()
+        -- print((vim.loop.hrtime() - start) / 1e6, 'ms')
+        --- ? some plugins use autocommands to redefine highlights
+        --- : clear again after a while
+        vim.defer_fn(clear, 500)
+        --- again
+        vim.defer_fn(clear, 1e3)
+        --- yes, clear 4 times!!!
+        vim.defer_fn(clear, 3e3)
+        --- Don't worry about performance, it's very cheap!
+        vim.defer_fn(clear, 5e3)
+    end
+    post_hook()
 end
 
 function M.toggle(opt)
@@ -79,6 +86,7 @@ function M.toggle(opt)
         pcall(vim.cmd.colorscheme, vim.g.colors_name)
     else
         clear()
+        post_hook()
     end
 end
 

--- a/lua/transparent/init.lua
+++ b/lua/transparent/init.lua
@@ -3,6 +3,8 @@ local M = {}
 local config = require("transparent.config")
 local cache = require("transparent.cache")
 
+local islist = vim.islist or vim.tbl_islist
+
 if vim.g.transparent_enabled == nil then
     cache.read()
 end
@@ -93,12 +95,7 @@ end
 function M.handle_groups_changed(arg)
     local old = arg.old or {}
     local new = arg.new or {}
-    if
-        type(old) == "table"
-        and type(new) == "table"
-        and vim.tbl_islist(old)
-        and vim.tbl_islist(new)
-    then
+    if type(old) == "table" and type(new) == "table" and islist(old) and islist(new) then
         clear_group(vim.tbl_filter(function(v)
             -- print(v)
             return not vim.tbl_contains(old, v)

--- a/lua/transparent/init.lua
+++ b/lua/transparent/init.lua
@@ -35,7 +35,7 @@ end
 local function clear()
     -- local start = vim.loop.hrtime()
 
-    if vim.g.transparent_enabled ~= true then
+    if not vim.g.transparent_enabled then
         return
     end
 
@@ -50,22 +50,24 @@ local function clear()
 end
 
 function M.clear()
-    if vim.g.transparent_enabled then
-        --- ? some plugins calculate colors from basic highlights
-        --- : clear immediately
-        -- local start = vim.loop.hrtime()
-        clear()
-        -- print((vim.loop.hrtime() - start) / 1e6, 'ms')
-        --- ? some plugins use autocommands to redefine highlights
-        --- : clear again after a while
-        vim.defer_fn(clear, 500)
-        --- again
-        vim.defer_fn(clear, 1e3)
-        --- yes, clear 4 times!!!
-        vim.defer_fn(clear, 3e3)
-        --- Don't worry about performance, it's very cheap!
-        vim.defer_fn(clear, 5e3)
+    if not vim.g.transparent_enabled then
+        return
     end
+
+    --- ? some plugins calculate colors from basic highlights
+    --- : clear immediately
+    -- local start = vim.loop.hrtime()
+    clear()
+    -- print((vim.loop.hrtime() - start) / 1e6, 'ms')
+    --- ? some plugins use autocommands to redefine highlights
+    --- : clear again after a while
+    vim.defer_fn(clear, 500)
+    --- again
+    vim.defer_fn(clear, 1e3)
+    --- yes, clear 4 times!!!
+    vim.defer_fn(clear, 3e3)
+    --- Don't worry about performance, it's very cheap!
+    vim.defer_fn(clear, 5e3)
 
     --- post hooks
     api.nvim_exec_autocmds("User", { pattern = "TransparentClear", modeline = false })


### PR DESCRIPTION
This adds both a `post_hook` option to the configuration options as well as a `TransparentClear` user autocommand event which provides the user 2 methods for executing code after highlight groups are cleared.

Resolves #62 

Note: this also has a 2nd commit that removes the use of `tbl_islist` in newer versions of Neovim. This function is now deprecated, so just future proofs the existing code slightly.