### PR TITLE
fix: fix `vim.validate` call

### DIFF
--- a/lua/transparent/config.lua
+++ b/lua/transparent/config.lua
@@ -18,9 +18,9 @@ local config = {
 function M.set(opts)
     vim.validate({
         groups = { opts.groups, "t", true },
-        extra_groups = { opts.groups, "t", true },
-        exclude_groups = { opts.groups, "t", true },
-        on_clear = { opts.groups, "f", true },
+        extra_groups = { opts.extra_groups, "t", true },
+        exclude_groups = { opts.exclude_groups, "t", true },
+        on_clear = { opts.on_clear, "f", true },
     })
     config = vim.tbl_extend("force", config, opts or {})
 end


### PR DESCRIPTION
Fixes copy/paste error in `vim.validate` call.