### PR TITLE
Fix regression introduced in d96b424: handle opts passed as nil

### DIFF
--- a/lua/transparent/config.lua
+++ b/lua/transparent/config.lua
@@ -16,8 +16,6 @@ local config = {
 -- stylua: ignore end
 
 function M.set(opts)
-    -- Handle regression if opts was not passed.
-    -- Behaviour existed prior to d96b424
     opts = opts or {}
 
     vim.validate({
@@ -26,7 +24,7 @@ function M.set(opts)
         exclude_groups = { opts.exclude_groups, "t", true },
         on_clear = { opts.on_clear, "f", true },
     })
-    config = vim.tbl_extend("force", config, opts or {})
+    config = vim.tbl_extend("force", config, opts)
 end
 
 return setmetatable(M, {

--- a/lua/transparent/config.lua
+++ b/lua/transparent/config.lua
@@ -16,6 +16,10 @@ local config = {
 -- stylua: ignore end
 
 function M.set(opts)
+    -- Handle regression if opts was not passed.
+    -- Behaviour existed prior to d96b424
+    opts = opts or {}
+
     vim.validate({
         groups = { opts.groups, "t", true },
         extra_groups = { opts.extra_groups, "t", true },


### PR DESCRIPTION
Previously, if opts was not passed into setup, the function would still succeed by falling back on default configurations. After commit d96b424, this behavior caused a crash when attempting to access keys in a nil dictionary. The regression occurred during the migration to the vim.validate API, where the fallback behavior for missing parameters was inadvertently removed. I'm not sure if Lua's documentation covers handling missing parameters, but this change restores the original fallback behavior and fixes the regression.

### The error I got after updating:
```
vim/_editor.lua:0: $HOME/dot-config/nvim/init.lua..nvim_exec2() called at $HOME/dot-config/nvim/init.lua:0..$HOME/dot-config/nvim/after/plugin/conf.lua: Vim(source):E5113: Error while calling lua chunk: ...re/nvim/lazy/transparent.nvim/lua/transparent/config.
lua:20: attempt to index local 'opts' (a nil value)
stack traceback:
^I...re/nvim/lazy/transparent.nvim/lua/transparent/config.lua:20: in function 'setup'
^I...e/$HOME/dot-config/nvim/after/plugin/conf.lua:7: in main chunk
^I[C]: in function 'nvim_exec2'
^Ivim/_editor.lua: in function 'cmd'
^I...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:503: in function <...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:502>
^I[C]: in function 'xpcall'
^I.../.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/util.lua:135: in function 'try'
^I...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:502: in function 'source'
^I...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:453: in function 'source_runtime'
^I...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:150: in function 'startup'
^I...omask/.local/share/nvim/lazy/lazy.nvim/lua/lazy/init.lua:112: in function 'setup'
^I$HOME/dot-config/nvim/init.lua:20: in main chunk
# stacktrace:
  - vim/_editor.lua:0 _in_ **cmd**
  - init.lua:20
```

