### PR TITLE
feat: Add remove_prefix & remove_all_prefix

### DIFF
--- a/lua/transparent/init.lua
+++ b/lua/transparent/init.lua
@@ -113,6 +113,22 @@ function M.clear_prefix(prefix)
     clear_group(fn.getcompletion(prefix, "highlight"))
 end
 
+function M.remove_prefix(prefix)
+    if not prefix or prefix == "" then
+        return
+    end
+
+    for index, value in pairs(group_prefix_list) do
+        if value:match(prefix) then
+            table.remove(group_prefix_list, index)
+        end
+    end
+end
+
+function M.remove_all_prefix()
+    group_prefix_list = {}
+end
+
 M.setup = config.set
 M.clear_group = clear_group
 


### PR DESCRIPTION
# Allow users to remove prefix

Now we can only doing `clear_prefix('prefix_str')`, but can't remove the added prefix. And I think to give users the ability to remove prefix will be better!

---

In my case, for example:

```lua
vim.api.nvim_create_autocmd({ 'ColorSchemePre' }, {
  callback = function()
    local curCS = vim.g.colors_name or ''
    if curCS:match('^tokyonight') then
      transparent.remove_prefix('SnacksPicker')
    else
      transparent.clear_prefix('SnacksPicker')
    end
  end,
})
```