### PR TITLE
Update config.lua to new vim.validate config, not the deprecated one …

### DIFF
--- a/lua/transparent/config.lua
+++ b/lua/transparent/config.lua
@@ -18,13 +18,11 @@ local config = {
 function M.set(opts)
     opts = opts or {}
 
-    vim.validate({
-        opts = { opts, "t" },
-        groups = { opts.groups, "t", true },
-        extra_groups = { opts.extra_groups, "t", true },
-        exclude_groups = { opts.exclude_groups, "t", true },
-        on_clear = { opts.on_clear, "f", true },
-    })
+    vim.validate("opts", opts, "table")
+    vim.validate("groups", opts.groups, "table", true)
+    vim.validate("extra_groups", opts.extra_groups, "table", true)
+    vim.validate("exclude_groups", opts.exclude_groups, "table", true)
+    vim.validate("on_clear", opts.on_clear, "function", true)
     config = vim.tbl_extend("force", config, opts)
 end
 


### PR DESCRIPTION
the vim.validate in the original repo is deprecated from neovim 0.11 and will be unsupported in neovim 1.0 ... this change update the way to use now vim.validate